### PR TITLE
Feat: Add Nix Flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,33 @@ If you do run into any issues, or have improvement suggestions, creating a [GitH
 
 ## Installation
 
+### Nix
+
+Add this flake to your `inputs` in `flake.nix`:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+	quickshell = {
+	  url = "git+https://git.outfoxxed.me/outfoxxed/quickshell";
+	  inputs.nixpkgs.follows = "nixpkgs";
+	};
+
+	qml-niri = {
+      url = "github:juuyokka/qml-niri/feat-nix-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+	  inputs.quickshell.follows = "quickshell";
+    };
+  };
+
+  # ...
+}
+```
+
+The plugin itself is available under `qml-niri.packages.<system>.default`. For those wishing to use it with Quickshell, the flake also provides a build of Quickshell with the plugin under `qml-niri.packages.<system>.quickshell`.
+
 ### Building from source
 
 Install [just](https://github.com/casey/just) and run:

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,43 @@
+{
+  version,
+  lib,
+  stdenv,
+  cmake,
+  qt6,
+  patchelf,
+}:
+
+let
+  qmlOutPath = "$out/${qt6.qtbase.qtQmlPrefix}";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qml-niri";
+  inherit version;
+
+  src = lib.cleanSource ./.;
+
+  nativeBuildInputs = [
+    cmake
+    patchelf
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+  ];
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    mkdir -p ${qmlOutPath}
+    cp -R Niri/ ${qmlOutPath}
+  '';
+
+  preFixup = ''
+    libDir="${qmlOutPath}/Niri"
+    for lib in $libDir/*.so; do
+      patchelf --remove-rpath "$lib" || true
+      patchelf --set-rpath "$libDir:${lib.makeLibraryPath finalAttrs.buildInputs}" "$lib" || true
+    done
+  '';
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,117 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1762040540,
+        "narHash": "sha256-z5PlZ47j50VNF3R+IMS9LmzI5fYRGY/Z5O5tol1c9I4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0010412d62a25d959151790968765a70c436598b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1762111121,
+        "narHash": "sha256-4vhDuZ7OZaZmKKrnDpxLZZpGIJvAeMtK6FKLJYUtAdw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1761236834,
+        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "quickshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1761897390,
+        "narHash": "sha256-er4gYrIoThYLjlsOMTysoRfn67d1Gci+ZpqDrtQxrA0=",
+        "ref": "refs/heads/master",
+        "rev": "fc704e6b5d445899a1565955268c91942a4f263f",
+        "revCount": 700,
+        "type": "git",
+        "url": "https://git.outfoxxed.me/outfoxxed/quickshell"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://git.outfoxxed.me/outfoxxed/quickshell"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "quickshell": "quickshell",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1762410071,
+        "narHash": "sha256-aF5fvoZeoXNPxT0bejFUBXeUjXfHLSL7g+mjR/p5TEg=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "97a30861b13c3731a84e09405414398fbf3e109f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    quickshell = {
+      url = "git+https://git.outfoxxed.me/outfoxxed/quickshell";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-parts,
+      ...
+    }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      { lib, ... }:
+      {
+        imports = [ inputs.treefmt-nix.flakeModule ];
+        systems = lib.intersectLists lib.systems.flakeExposed lib.platforms.linux;
+
+        perSystem =
+          {
+            self',
+            inputs',
+            pkgs,
+            ...
+          }:
+          {
+            treefmt = {
+              projectRootFile = "flake.nix";
+              programs.nixfmt.enable = true;
+            };
+
+            packages = {
+              default = self'.packages.qml-niri;
+              qml-niri = pkgs.callPackage ./default.nix {
+                version = self.sourceInfo.dirtyShortRev or self.sourceInfo.shortRev;
+              };
+
+              quickshell = self'.packages.quickshell-niri;
+              quickshell-niri = inputs'.quickshell.packages.default.overrideAttrs (prevAttrs: {
+                buildInputs = [ self'.packages.qml-niri ] ++ prevAttrs.buildInputs;
+              });
+            };
+          };
+      }
+    );
+}


### PR DESCRIPTION
This PR adds a basic Nix flake using flake-parts to provide two packages for Nix users:

- The qml-niri plugin itself
- Quickshell with qml-niri support built in

It's mostly a "set it and forget it" kind of deal as it is quite simple. I have also added instructions on how to use the packages in the README, but note that the url points to my fork, so please change it upon merging.

Great work bridging the gap for niri users!