### PR TITLE
Generate the QML type info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,28 +7,32 @@ set(CMAKE_AUTOMOC ON)
 
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Qml)
 
-add_library(niriplugin SHARED
-    src/icon.cpp
-    src/ipcclient.cpp
-    src/logging.cpp
-    src/niri.cpp
-    src/plugin.cpp
-    src/windowmodel.cpp
-    src/workspacemodel.cpp
+qt_standard_project_setup(REQUIRES 6.5)
+
+qt_add_library(Niri SHARED)
+
+set_target_properties(Niri PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Niri
 )
 
-target_link_libraries(niriplugin
+qt_add_qml_module(Niri
+        URI Niri
+    VERSION 0.1.1
+    SOURCES
+        src/icon.h src/icon.cpp
+        src/ipcclient.h src/ipcclient.cpp
+        src/logging.cpp
+        src/niri.h src/niri.cpp
+        src/windowmodel.h src/windowmodel.cpp
+        src/workspacemodel.h src/workspacemodel.cpp
+    OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Niri
+)
+
+target_include_directories(Niri PUBLIC src)
+
+target_link_libraries(Niri PRIVATE
     Qt6::Core
     Qt6::Gui
     Qt6::Qml
 )
 
-set_target_properties(niriplugin PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Niri
-)
-
-add_custom_command(TARGET niriplugin POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-    ${CMAKE_SOURCE_DIR}/src/qmldir
-    ${CMAKE_BINARY_DIR}/Niri/qmldir
-)

--- a/src/niri.h
+++ b/src/niri.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QQmlEngine>
 #include "ipcclient.h"
 #include "workspacemodel.h"
 #include "windowmodel.h"
@@ -8,6 +9,7 @@
 class Niri : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
     Q_PROPERTY(WorkspaceModel* workspaces READ workspaces CONSTANT)
     Q_PROPERTY(WindowModel* windows READ windows CONSTANT)
     Q_PROPERTY(Window* focusedWindow READ focusedWindow NOTIFY focusedWindowChanged)

--- a/src/qmldir
+++ b/src/qmldir
@@ -1,2 +1,0 @@
-module Niri
-plugin niriplugin

--- a/src/windowmodel.h
+++ b/src/windowmodel.h
@@ -3,10 +3,12 @@
 #include <QAbstractListModel>
 #include <QJsonObject>
 #include <QObject>
+#include <QQmlEngine>
 
 class Window : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
     Q_PROPERTY(quint64 id MEMBER id CONSTANT)
     Q_PROPERTY(QString title MEMBER title CONSTANT)
     Q_PROPERTY(QString appId MEMBER appId CONSTANT)
@@ -36,6 +38,7 @@ public:
 class WindowModel : public QAbstractListModel
 {
     Q_OBJECT
+    QML_ELEMENT
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
     Q_PROPERTY(Window* focusedWindow READ focusedWindow NOTIFY focusedWindowChanged)
 

--- a/src/workspacemodel.h
+++ b/src/workspacemodel.h
@@ -2,6 +2,7 @@
 
 #include <QAbstractListModel>
 #include <QJsonObject>
+#include <QQmlEngine>
 
 struct Workspace {
     quint64 id;
@@ -17,6 +18,7 @@ struct Workspace {
 class WorkspaceModel : public QAbstractListModel
 {
     Q_OBJECT
+    QML_ELEMENT
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
     Q_PROPERTY(int maxCount READ maxCount WRITE setMaxCount NOTIFY maxCountChanged)
 


### PR DESCRIPTION
I modified the build system to generate the QML type info, to be able to use the QML language server (qmlls).

I don't know the QT build system and did my best to follow the documentation, I'm able to compile this cleanly and use the resulting library.
