### PR TITLE
sort windows by position in layout, not id

### DIFF
--- a/src/windowmodel.h
+++ b/src/windowmodel.h
@@ -33,6 +33,8 @@ public:
     bool isFloating;
     bool isUrgent;
     QString iconPath;
+    std::optional<qint64> scroll_column;
+    std::optional<qint64> scroll_tile;
 };
 
 class WindowModel : public QAbstractListModel


### PR DESCRIPTION
this is the patch i mentioned in #5. it isn't perfect, but i believe the behaviour here is strongly preferable to the current behaviour