### PR TITLE
feat: respect XDG environment variables in icon lookup

### DIFF
--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -115,9 +115,11 @@ QStringList getXdgIconDirs()
         }
     }
 
-    QString pixmaps = "/usr/share/pixmaps";
-    if (QDir(pixmaps).exists()) {
-        iconDirs.append(pixmaps);
+    for (const QString &dir : xdgDataDirs.split(':', Qt::SkipEmptyParts)) {
+        QString pixmapsDir = dir + "/pixmaps";
+        if (QDir(pixmapsDir).exists() && !iconDirs.contains(pixmapsDir)) {
+            iconDirs.append(pixmapsDir);
+        }
     }
 
     return iconDirs;

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -72,17 +72,55 @@ namespace Internal {
 QStringList getXdgDataDirs()
 {
     QStringList dirs;
-
-    QString homeLocal = QDir::homePath() + "/.local/share";
-    dirs.append(homeLocal);
-
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-    QString xdgDataDirs = env.value("XDG_DATA_DIRS", "/usr/local/share:/usr/share");
 
+    QString xdgDataHome = env.value("XDG_DATA_HOME");
+    if (xdgDataHome.isEmpty()) {
+        xdgDataHome = QDir::homePath() + "/.local/share";
+    }
+    dirs.append(xdgDataHome);
+
+    QString xdgDataDirs = env.value("XDG_DATA_DIRS", "/usr/local/share:/usr/share");
     dirs.append(xdgDataDirs.split(':', Qt::SkipEmptyParts));
+
     dirs.removeDuplicates();
 
     return dirs;
+}
+
+QStringList getXdgIconDirs()
+{
+    QStringList iconDirs;
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+
+    QString legacyIcons = QDir::homePath() + "/.icons";
+    if (QDir(legacyIcons).exists()) {
+        iconDirs.append(legacyIcons);
+    }
+
+    QString xdgDataHome = env.value("XDG_DATA_HOME");
+    if (xdgDataHome.isEmpty()) {
+        xdgDataHome = QDir::homePath() + "/.local/share";
+    }
+    QString userIcons = xdgDataHome + "/icons";
+    if (QDir(userIcons).exists()) {
+        iconDirs.append(userIcons);
+    }
+
+    QString xdgDataDirs = env.value("XDG_DATA_DIRS", "/usr/local/share:/usr/share");
+    for (const QString &dir : xdgDataDirs.split(':', Qt::SkipEmptyParts)) {
+        QString iconDir = dir + "/icons";
+        if (QDir(iconDir).exists() && !iconDirs.contains(iconDir)) {
+            iconDirs.append(iconDir);
+        }
+    }
+
+    QString pixmaps = "/usr/share/pixmaps";
+    if (QDir(pixmaps).exists()) {
+        iconDirs.append(pixmaps);
+    }
+
+    return iconDirs;
 }
 
 QString findDesktopFile(const QString &appId)
@@ -219,23 +257,7 @@ QString resolveIconPath(const QString &iconValue, const QString &desktopFileDir)
 
 QString findIconInTheme(const QString &iconName)
 {
-    QStringList iconDirs;
-
-    // User icon directories
-    QString homeIcons = QDir::homePath() + "/.local/share/icons";
-    if (QDir(homeIcons).exists()) {
-        iconDirs.append(homeIcons);
-    }
-
-    QString homeIconsLegacy = QDir::homePath() + "/.icons";
-    if (QDir(homeIconsLegacy).exists()) {
-        iconDirs.append(homeIconsLegacy);
-    }
-
-    // System icon directories
-    iconDirs.append("/usr/share/icons");
-    iconDirs.append("/usr/local/share/icons");
-    iconDirs.append("/usr/share/pixmaps");
+    QStringList iconDirs = getXdgIconDirs();
 
     QStringList themes;
 

--- a/src/icon.h
+++ b/src/icon.h
@@ -26,6 +26,7 @@ namespace Internal {
     QString resolveIconPath(const QString &iconValue, const QString &desktopFileDir);
     QString findIconInTheme(const QString &iconName);
     QStringList getXdgDataDirs();
+    QStringList getXdgIconDirs();
 }
 
 } // namespace IconLookup


### PR DESCRIPTION
I noticed qml-niri was always returning empty `iconPath` values on my nixos system. This is because nixos stores packages in `/nix/store` paths rather than typical locations like `/usr/share`. While qml-niri does use `XDG_DATA_DIRS` to find desktop files, it doesn't do so when finding icons.

I fixed the icon lookup to properly respect `XDG_DATA_HOME` and `XDG_DATA_DIRS` environment variables per [freedesktop specifications](https://specifications.freedesktop.org/icon-theme/latest/#directory_layout).