### PR TITLE
Handle Layout Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ Available window properties:
   - `window_offset_in_tile`: Location of the window's visual geometry within its tile
   - `window_size`: Size of the window's visual geometry itself, not including decorations
 
+Windows are sorted by their position in the scrolling layout.
+
 #### Application icons
 
 Application icons are automatically looked up using XDG desktop entries, and can be rendered like so:

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Pull requests to improve the testing situation, add unit tests, etc., are very w
 - `errorOccurred(error)` - Emitted on error
 - `rawEventReceived(event)` - Emitted for all IPC events
 - `focusedWindowChanged()` - Emitted when focused window changes or its properties update
+- `windowLayoutChanged()` - Emitted when a window is moved in the layout
 
 
 ## Quickshell integration

--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ Available window properties:
 - `isFloating`: Floating window state
 - `isUrgent`: Window urgency flag
 - `iconPath`: Absolute path to application icon (empty if not found)
+- `layout`: Window layout properties
+  - `pos_in_scrolling_layout`: Location of a tiled window within a workspace
+  - `tile_pos_in_workspace_view`: Tile position within the current view of the workspace
+  - `tile_size`: Size of the tile this window is in, including decorations
+  - `window_offset_in_tile`: Location of the window's visual geometry within its tile
+  - `window_size`: Size of the window's visual geometry itself, not including decorations
 
 #### Application icons
 

--- a/src/niri.cpp
+++ b/src/niri.cpp
@@ -30,6 +30,10 @@ Niri::Niri(QObject *parent)
     // Forward focused window changes
     QObject::connect(m_windowModel, &WindowModel::focusedWindowChanged,
                      this, &Niri::focusedWindowChanged);
+
+    // Forward window layouts changes
+    QObject::connect(m_windowModel, &WindowModel::windowLayoutsChanged,
+                     this, &Niri::windowLayoutsChanged);
 }
 
 Niri::~Niri()

--- a/src/niri.cpp
+++ b/src/niri.cpp
@@ -32,8 +32,8 @@ Niri::Niri(QObject *parent)
                      this, &Niri::focusedWindowChanged);
 
     // Forward window layouts changes
-    QObject::connect(m_windowModel, &WindowModel::layoutChanged,
-                     this, &Niri::layoutChanged);
+    QObject::connect(m_windowModel, &WindowModel::windowLayoutChanged,
+                     this, &Niri::windowLayoutChanged);
 }
 
 Niri::~Niri()

--- a/src/niri.cpp
+++ b/src/niri.cpp
@@ -32,8 +32,8 @@ Niri::Niri(QObject *parent)
                      this, &Niri::focusedWindowChanged);
 
     // Forward window layouts changes
-    QObject::connect(m_windowModel, &WindowModel::windowLayoutsChanged,
-                     this, &Niri::windowLayoutsChanged);
+    QObject::connect(m_windowModel, &WindowModel::layoutChanged,
+                     this, &Niri::layoutChanged);
 }
 
 Niri::~Niri()

--- a/src/niri.h
+++ b/src/niri.h
@@ -13,6 +13,7 @@ class Niri : public QObject
     Q_PROPERTY(WorkspaceModel* workspaces READ workspaces CONSTANT)
     Q_PROPERTY(WindowModel* windows READ windows CONSTANT)
     Q_PROPERTY(Window* focusedWindow READ focusedWindow NOTIFY focusedWindowChanged)
+    Q_PROPERTY(QJsonObject windowLayouts READ windowLayouts NOTIFY windowLayoutsChanged)
 
 public:
     explicit Niri(QObject *parent = nullptr);
@@ -21,6 +22,7 @@ public:
     WorkspaceModel* workspaces() const { return m_workspaceModel; }
     WindowModel* windows() const { return m_windowModel; }
     Window* focusedWindow() const;
+    QJsonObject windowLayouts() const;
 
     Q_INVOKABLE bool connect();
     Q_INVOKABLE bool isConnected() const;
@@ -39,6 +41,7 @@ signals:
     void errorOccurred(const QString &error);
     void rawEventReceived(const QJsonObject &event);
     void focusedWindowChanged();
+    void windowLayoutsChanged();
 
 private:
     void sendAction(const QJsonObject &action);

--- a/src/niri.h
+++ b/src/niri.h
@@ -13,7 +13,6 @@ class Niri : public QObject
     Q_PROPERTY(WorkspaceModel* workspaces READ workspaces CONSTANT)
     Q_PROPERTY(WindowModel* windows READ windows CONSTANT)
     Q_PROPERTY(Window* focusedWindow READ focusedWindow NOTIFY focusedWindowChanged)
-    Q_PROPERTY(QVariant layout READ windowLayout NOTIFY layoutChanged)
 
 public:
     explicit Niri(QObject *parent = nullptr);
@@ -22,7 +21,6 @@ public:
     WorkspaceModel* workspaces() const { return m_workspaceModel; }
     WindowModel* windows() const { return m_windowModel; }
     Window* focusedWindow() const;
-    QVariant windowLayout() const;
 
     Q_INVOKABLE bool connect();
     Q_INVOKABLE bool isConnected() const;
@@ -41,7 +39,7 @@ signals:
     void errorOccurred(const QString &error);
     void rawEventReceived(const QJsonObject &event);
     void focusedWindowChanged();
-    void layoutChanged();
+    void windowLayoutChanged();
 
 private:
     void sendAction(const QJsonObject &action);

--- a/src/niri.h
+++ b/src/niri.h
@@ -13,7 +13,7 @@ class Niri : public QObject
     Q_PROPERTY(WorkspaceModel* workspaces READ workspaces CONSTANT)
     Q_PROPERTY(WindowModel* windows READ windows CONSTANT)
     Q_PROPERTY(Window* focusedWindow READ focusedWindow NOTIFY focusedWindowChanged)
-    Q_PROPERTY(QJsonObject windowLayouts READ windowLayouts NOTIFY windowLayoutsChanged)
+    Q_PROPERTY(QVariant layout READ windowLayout NOTIFY layoutChanged)
 
 public:
     explicit Niri(QObject *parent = nullptr);
@@ -22,7 +22,7 @@ public:
     WorkspaceModel* workspaces() const { return m_workspaceModel; }
     WindowModel* windows() const { return m_windowModel; }
     Window* focusedWindow() const;
-    QJsonObject windowLayouts() const;
+    QVariant windowLayout() const;
 
     Q_INVOKABLE bool connect();
     Q_INVOKABLE bool isConnected() const;
@@ -41,7 +41,7 @@ signals:
     void errorOccurred(const QString &error);
     void rawEventReceived(const QJsonObject &event);
     void focusedWindowChanged();
-    void windowLayoutsChanged();
+    void layoutChanged();
 
 private:
     void sendAction(const QJsonObject &action);

--- a/src/windowmodel.cpp
+++ b/src/windowmodel.cpp
@@ -212,6 +212,8 @@ void WindowModel::handleWindowUrgencyChanged(quint64 id, bool urgent)
 
 void WindowModel::handleWindowLayoutsChanged(const QJsonArray &changes)
 {
+    qCWarning(niriLog) << "handleWindowLayoutsChanged() changes: " << changes;
+
     for (const QJsonValue &entry : changes) {
         const QJsonArray pair = entry.toArray();
         quint64 idValue = pair[0].toInt();
@@ -228,7 +230,8 @@ void WindowModel::handleWindowLayoutsChanged(const QJsonArray &changes)
         win->layout = layoutObj;
 
         QModelIndex modelIdx = index(idx);
-        emit dataChanged(modelIdx, modelIdx, {LayoutRole});
+        //emit dataChanged(modelIdx, modelIdx, {LayoutRole});
+        emit windowLayoutsChanged();
     }
 }
 
@@ -249,10 +252,9 @@ Window* WindowModel::parseWindow(const QJsonObject &obj)
     win->isFloating = obj["is_floating"].toBool();
     win->isUrgent = obj["is_urgent"].toBool();
     win->iconPath = IconLookup::lookup(win->appId);
+    win->layout = obj["layout"].toObject();
 
-    if (obj.contains("layout") && obj["layout"].isObject()) {
-        win->layout = obj["layout"].toObject();
-    }
+    qCWarning(niriLog) << "parseWindow() layout: " << win->layout;
 
     return win;
 }

--- a/src/windowmodel.cpp
+++ b/src/windowmodel.cpp
@@ -10,11 +10,6 @@ WindowModel::WindowModel(QObject *parent)
 {
 }
 
-WindowLayoutModel::WindowLayoutModel(QObject *parent)
-    : QAbstractListModel(parent)
-{
-}
-
 WindowModel::~WindowModel()
 {
     qDeleteAll(m_windows);
@@ -73,41 +68,6 @@ QHash<int, QByteArray> WindowModel::roleNames() const
     roles[IsUrgentRole] = "isUrgent";
     roles[IconPathRole] = "iconPath";
     roles[LayoutRole] = "layout";
-
-    return roles;
-}
-
-QVariant WindowLayoutModel::data(const QModelIndex &index, int role) const
-{
-    if (!index.isValid() || index.row() >= m_windows.count())
-        return QVariant();
-
-    const Window *win = m_windows.at(index.row());
-
-    switch (role) {
-    case PosInScrollingLayoutRole:
-        return QVariant::fromValue(win->layout->posInScrollingLayout);
-    case TileSizeRole:
-        return QVariant::fromValue(win->layout->tileSize);
-    case WindowSizeRole:
-        return QVariant::fromValue(win->layout->windowSize);
-    case TilePosInWorkspaceViewRole:
-        return QVariant::fromValue(win->layout->tilePosInWorkspaceView);
-    case WindowOffsetInTileRole:
-        return QVariant::fromValue(win->layout->windowOffsetInTile);
-    default:
-        return QVariant();
-    }
-}
-
-QHash<int, QByteArray> WindowLayoutModel::roleNames() const
-{
-    QHash<int, QByteArray> roles;
-    roles[PosInScrollingLayoutRole] = "posInScrollingLayout";
-    roles[TileSizeRole] = "tileSize";
-    roles[WindowSizeRole] = "windowSize";
-    roles[TilePosInWorkspaceViewRole] = "tilePosInWorkspaceView";
-    roles[WindowOffsetInTileRole] = "windowOffsetInTile";
 
     return roles;
 }
@@ -265,11 +225,7 @@ void WindowModel::handleWindowLayoutsChanged(const QJsonArray &changes)
 
         Window *win = m_windows.at(idx);
 
-        win->layout->posInScrollingLayout = layoutObj["pos_in_scrolling_layout"].toVariant().toList();
-        win->layout->tileSize = layoutObj["tile_size"].toVariant().toList();
-        win->layout->windowSize = layoutObj["window_size"].toVariant().toList();
-        win->layout->tilePosInWorkspaceView = layoutObj["window_pos_in_workspace_view"].toVariant().toList();
-        win->layout->windowOffsetInTile = layoutObj["window_offset_in_tile"].toVariant().toList();
+        win->layout = layoutObj;
 
         QModelIndex modelIdx = index(idx);
         emit dataChanged(modelIdx, modelIdx, {LayoutRole});
@@ -295,13 +251,7 @@ Window* WindowModel::parseWindow(const QJsonObject &obj)
     win->iconPath = IconLookup::lookup(win->appId);
 
     if (obj.contains("layout") && obj["layout"].isObject()) {
-        QJsonObject layoutObj = obj["layout"].toObject();
-
-        win->layout->posInScrollingLayout   = layoutObj["pos_in_scrolling_layout"].toVariant().toList();
-        win->layout->tileSize               = layoutObj["tile_size"].toVariant().toList();
-        win->layout->windowSize             = layoutObj["window_size"].toVariant().toList();
-        win->layout->tilePosInWorkspaceView = layoutObj["window_pos_in_workspace_view"].toVariant().toList();
-        win->layout->windowOffsetInTile     = layoutObj["window_offset_in_tile"].toVariant().toList();
+        win->layout = obj["layout"].toObject();
     }
 
     return win;

--- a/src/windowmodel.cpp
+++ b/src/windowmodel.cpp
@@ -212,8 +212,6 @@ void WindowModel::handleWindowUrgencyChanged(quint64 id, bool urgent)
 
 void WindowModel::handleWindowLayoutsChanged(const QJsonArray &changes)
 {
-    qCWarning(niriLog) << "handleWindowLayoutsChanged() changes: " << changes;
-
     for (const QJsonValue &entry : changes) {
         const QJsonArray pair = entry.toArray();
         quint64 idValue = pair[0].toInt();

--- a/src/windowmodel.cpp
+++ b/src/windowmodel.cpp
@@ -226,13 +226,10 @@ void WindowModel::handleWindowLayoutsChanged(const QJsonArray &changes)
         }
 
         Window *win = m_windows.at(idx);
-
         win->layout = layoutObj;
-
-        QModelIndex modelIdx = index(idx);
-        //emit dataChanged(modelIdx, modelIdx, {LayoutRole});
-        emit windowLayoutsChanged();
     }
+
+    emit windowLayoutsChanged();
 }
 
 Window* WindowModel::parseWindow(const QJsonObject &obj)
@@ -253,8 +250,6 @@ Window* WindowModel::parseWindow(const QJsonObject &obj)
     win->isUrgent = obj["is_urgent"].toBool();
     win->iconPath = IconLookup::lookup(win->appId);
     win->layout = obj["layout"].toObject();
-
-    qCWarning(niriLog) << "parseWindow() layout: " << win->layout;
 
     return win;
 }

--- a/src/windowmodel.cpp
+++ b/src/windowmodel.cpp
@@ -269,7 +269,7 @@ void WindowModel::handleWindowLayoutsChanged(const QJsonArray &changes)
         win->layout->tileSize = layoutObj["tile_size"].toVariant().toList();
         win->layout->windowSize = layoutObj["window_size"].toVariant().toList();
         win->layout->tilePosInWorkspaceView = layoutObj["window_pos_in_workspace_view"].toVariant().toList();
-        win->layout->windowOffsetInTile = layoutObj["window_offset_in_title"].toVariant().toList();
+        win->layout->windowOffsetInTile = layoutObj["window_offset_in_tile"].toVariant().toList();
 
         QModelIndex modelIdx = index(idx);
         emit dataChanged(modelIdx, modelIdx, {LayoutRole});
@@ -294,11 +294,15 @@ Window* WindowModel::parseWindow(const QJsonObject &obj)
     win->isUrgent = obj["is_urgent"].toBool();
     win->iconPath = IconLookup::lookup(win->appId);
 
-    //win->layout->posInScrollingLayout = changes["pos_in_scrolling_layout"];
-    //win->layout->tileSize = changes["tile_size"];
-    //win->layout->windowSize = changes["window_size"];
-    //win->layout->tilePosInWorkspaceView = changes["window_pos_in_workspace_view];
-    //win->layout->windowOffsetInTile = changes["window_offset_in_title"];
+    if (obj.contains("layout") && obj["layout"].isObject()) {
+        QJsonObject layoutObj = obj["layout"].toObject();
+
+        win->layout->posInScrollingLayout   = layoutObj["pos_in_scrolling_layout"].toVariant().toList();
+        win->layout->tileSize               = layoutObj["tile_size"].toVariant().toList();
+        win->layout->windowSize             = layoutObj["window_size"].toVariant().toList();
+        win->layout->tilePosInWorkspaceView = layoutObj["window_pos_in_workspace_view"].toVariant().toList();
+        win->layout->windowOffsetInTile     = layoutObj["window_offset_in_tile"].toVariant().toList();
+    }
 
     return win;
 }

--- a/src/windowmodel.cpp
+++ b/src/windowmodel.cpp
@@ -22,15 +22,6 @@ int WindowModel::rowCount(const QModelIndex &parent) const
     return m_windows.count();
 }
 
-QVariant WindowModel::windowLayout(const QModelIndex &index) const
-{
-    if (!index.isValid())
-        return QVariant();
-
-    const Window *win = m_windows.at(index.row());
-    return QVariant::fromValue(win->layout);
-}
-
 QVariant WindowModel::data(const QModelIndex &index, int role) const
 {
     if (!index.isValid() || index.row() >= m_windows.count())

--- a/src/windowmodel.cpp
+++ b/src/windowmodel.cpp
@@ -243,7 +243,7 @@ void WindowModel::handleWindowLayoutsChanged(const QJsonArray &changes)
     }
     sortWindowsByScrollingPosition();
     endResetModel();
-    emit layoutChanged();
+    emit windowLayoutChanged();
 }
 
 Window* WindowModel::parseWindow(const QJsonObject &obj)

--- a/src/windowmodel.cpp
+++ b/src/windowmodel.cpp
@@ -22,6 +22,15 @@ int WindowModel::rowCount(const QModelIndex &parent) const
     return m_windows.count();
 }
 
+QVariant WindowModel::windowLayout(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return QVariant();
+
+    const Window *win = m_windows.at(index.row());
+    return QVariant::fromValue(win->layout);
+}
+
 QVariant WindowModel::data(const QModelIndex &index, int role) const
 {
     if (!index.isValid() || index.row() >= m_windows.count())
@@ -102,6 +111,22 @@ void WindowModel::handleEvent(const QJsonObject &event)
     }
 }
 
+void WindowModel::sortWindowsByScrollingPosition()
+{
+    std::sort(m_windows.begin(), m_windows.end(),
+        [](const Window *a, const Window *b) {
+            const auto [colA, tileA] = std::pair{
+                a->layout["pos_in_scrolling_layout"][0].toInt(),
+                a->layout["pos_in_scrolling_layout"][1].toInt()
+            };
+            const auto [colB, tileB] = std::pair{
+                b->layout["pos_in_scrolling_layout"][0].toInt(),
+                b->layout["pos_in_scrolling_layout"][1].toInt()
+            };
+            return (tileA != tileB) ? (tileA < tileB) : (colA < colB);
+        });
+}
+
 void WindowModel::handleWindowsChanged(const QJsonArray &windows)
 {
     beginResetModel();
@@ -114,12 +139,7 @@ void WindowModel::handleWindowsChanged(const QJsonArray &windows)
         }
     }
 
-    // Sort by window ID for consistent ordering
-    std::sort(m_windows.begin(), m_windows.end(),
-              [](const Window *a, const Window *b) {
-                return a->id < b->id;
-              });
-
+    sortWindowsByScrollingPosition();
     endResetModel();
     emit countChanged();
     updateFocusedWindow();
@@ -212,6 +232,7 @@ void WindowModel::handleWindowUrgencyChanged(quint64 id, bool urgent)
 
 void WindowModel::handleWindowLayoutsChanged(const QJsonArray &changes)
 {
+    beginResetModel();
     for (const QJsonValue &entry : changes) {
         const QJsonArray pair = entry.toArray();
         quint64 idValue = pair[0].toInt();
@@ -225,9 +246,13 @@ void WindowModel::handleWindowLayoutsChanged(const QJsonArray &changes)
 
         Window *win = m_windows.at(idx);
         win->layout = layoutObj;
-    }
 
-    emit windowLayoutsChanged();
+        QModelIndex modelIdx = index(idx);
+        emit dataChanged(modelIdx, modelIdx, {LayoutRole});
+    }
+    sortWindowsByScrollingPosition();
+    endResetModel();
+    emit layoutChanged();
 }
 
 Window* WindowModel::parseWindow(const QJsonObject &obj)

--- a/src/windowmodel.h
+++ b/src/windowmodel.h
@@ -5,6 +5,32 @@
 #include <QObject>
 #include <QQmlEngine>
 
+class WindowLayout : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    Q_PROPERTY(QVariant posInScrollingLayout MEMBER posInScrollingLayout CONSTANT)
+    Q_PROPERTY(QVariant tileSize MEMBER tileSize CONSTANT)
+    Q_PROPERTY(QVariant windowSize MEMBER windowSize CONSTANT)
+    Q_PROPERTY(QVariant tilePosInWorkspaceView MEMBER tilePosInWorkspaceView CONSTANT)
+    Q_PROPERTY(QVariant windowOffsetInTile MEMBER windowOffsetInTile CONSTANT)
+
+public:
+    explicit WindowLayout(QObject *parent = nullptr)
+        : QObject(parent),
+          posInScrollingLayout(QVariant()),
+          tileSize(QVariantList{0.0, 0.0}),
+          windowSize(QVariantList{0, 0}),
+          tilePosInWorkspaceView(QVariant()),
+          windowOffsetInTile(QVariantList{0.0, 0.0}) {}
+
+    QVariant posInScrollingLayout;
+    QVariantList tileSize;
+    QVariantList windowSize;
+    QVariant tilePosInWorkspaceView;
+    QVariantList windowOffsetInTile;
+};
+
 class Window : public QObject
 {
     Q_OBJECT
@@ -18,11 +44,13 @@ class Window : public QObject
     Q_PROPERTY(bool isFloating MEMBER isFloating CONSTANT)
     Q_PROPERTY(bool isUrgent MEMBER isUrgent CONSTANT)
     Q_PROPERTY(QString iconPath MEMBER iconPath CONSTANT)
+    Q_PROPERTY(WindowLayout* layout MEMBER layout CONSTANT)
 
 public:
     explicit Window(QObject *parent = nullptr)
         : QObject(parent), id(0), pid(-1), workspaceId(0),
-          isFocused(false), isFloating(false), isUrgent(false) {}
+          isFocused(false), isFloating(false), isUrgent(false),
+          layout() {}
 
     quint64 id;
     QString title;
@@ -33,6 +61,32 @@ public:
     bool isFloating;
     bool isUrgent;
     QString iconPath;
+    WindowLayout* layout;
+};
+
+class WindowLayoutModel : public QAbstractListModel
+{
+    Q_OBJECT
+    QML_ELEMENT
+    //Q_PROPERTY(WindowLayout* focusedWindow READ focusedWindow NOTIFY focusedWindowChanged)
+
+public:
+    enum WindowLayoutRoles {
+        PosInScrollingLayoutRole,
+        TileSizeRole,
+        WindowSizeRole,
+        TilePosInWorkspaceViewRole,
+        WindowOffsetInTileRole
+    };
+
+    explicit WindowLayoutModel(QObject *parent = nullptr);
+    ~WindowLayoutModel();
+
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+private:
+    QList<Window*> m_windows;
 };
 
 class WindowModel : public QAbstractListModel
@@ -52,7 +106,8 @@ public:
         IsFocusedRole,
         IsFloatingRole,
         IsUrgentRole,
-        IconPathRole
+        IconPathRole,
+        LayoutRole
     };
 
     explicit WindowModel(QObject *parent = nullptr);

--- a/src/windowmodel.h
+++ b/src/windowmodel.h
@@ -44,6 +44,7 @@ class WindowModel : public QAbstractListModel
     QML_ELEMENT
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
     Q_PROPERTY(Window* focusedWindow READ focusedWindow NOTIFY focusedWindowChanged)
+    Q_PROPERTY(QJsonObject windowLayouts READ windowLayouts NOTIFY windowLayoutsChanged)
 
 public:
     enum WindowRoles {
@@ -67,6 +68,7 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     Window* focusedWindow() const { return m_focusedWindow; }
+    QJsonObject windowLayouts() const { return m_windowLayouts; }
 
 public slots:
     void handleEvent(const QJsonObject &event);
@@ -74,6 +76,7 @@ public slots:
 signals:
     void countChanged();
     void focusedWindowChanged();
+    void windowLayoutsChanged();
 
 private:
     void handleWindowsChanged(const QJsonArray &windows);
@@ -89,4 +92,5 @@ private:
 
     QList<Window*> m_windows;
     Window *m_focusedWindow = nullptr;
+    QJsonObject m_windowLayouts;
 };

--- a/src/windowmodel.h
+++ b/src/windowmodel.h
@@ -68,7 +68,6 @@ class WindowLayoutModel : public QAbstractListModel
 {
     Q_OBJECT
     QML_ELEMENT
-    //Q_PROPERTY(WindowLayout* focusedWindow READ focusedWindow NOTIFY focusedWindowChanged)
 
 public:
     enum WindowLayoutRoles {

--- a/src/windowmodel.h
+++ b/src/windowmodel.h
@@ -5,32 +5,6 @@
 #include <QObject>
 #include <QQmlEngine>
 
-class WindowLayout : public QObject
-{
-    Q_OBJECT
-    QML_ELEMENT
-    Q_PROPERTY(QVariant posInScrollingLayout MEMBER posInScrollingLayout CONSTANT)
-    Q_PROPERTY(QVariant tileSize MEMBER tileSize CONSTANT)
-    Q_PROPERTY(QVariant windowSize MEMBER windowSize CONSTANT)
-    Q_PROPERTY(QVariant tilePosInWorkspaceView MEMBER tilePosInWorkspaceView CONSTANT)
-    Q_PROPERTY(QVariant windowOffsetInTile MEMBER windowOffsetInTile CONSTANT)
-
-public:
-    explicit WindowLayout(QObject *parent = nullptr)
-        : QObject(parent),
-          posInScrollingLayout(QVariant()),
-          tileSize(QVariantList{0.0, 0.0}),
-          windowSize(QVariantList{0, 0}),
-          tilePosInWorkspaceView(QVariant()),
-          windowOffsetInTile(QVariantList{0.0, 0.0}) {}
-
-    QVariant posInScrollingLayout;
-    QVariantList tileSize;
-    QVariantList windowSize;
-    QVariant tilePosInWorkspaceView;
-    QVariantList windowOffsetInTile;
-};
-
 class Window : public QObject
 {
     Q_OBJECT
@@ -44,13 +18,13 @@ class Window : public QObject
     Q_PROPERTY(bool isFloating MEMBER isFloating CONSTANT)
     Q_PROPERTY(bool isUrgent MEMBER isUrgent CONSTANT)
     Q_PROPERTY(QString iconPath MEMBER iconPath CONSTANT)
-    Q_PROPERTY(WindowLayout* layout MEMBER layout CONSTANT)
+    Q_PROPERTY(QJsonObject layout MEMBER layout CONSTANT)
 
 public:
     explicit Window(QObject *parent = nullptr)
         : QObject(parent), id(0), pid(-1), workspaceId(0),
           isFocused(false), isFloating(false), isUrgent(false),
-          layout() {}
+          layout(QJsonObject()) {}
 
     quint64 id;
     QString title;
@@ -61,31 +35,7 @@ public:
     bool isFloating;
     bool isUrgent;
     QString iconPath;
-    WindowLayout* layout;
-};
-
-class WindowLayoutModel : public QAbstractListModel
-{
-    Q_OBJECT
-    QML_ELEMENT
-
-public:
-    enum WindowLayoutRoles {
-        PosInScrollingLayoutRole,
-        TileSizeRole,
-        WindowSizeRole,
-        TilePosInWorkspaceViewRole,
-        WindowOffsetInTileRole
-    };
-
-    explicit WindowLayoutModel(QObject *parent = nullptr);
-    ~WindowLayoutModel();
-
-    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-    QHash<int, QByteArray> roleNames() const override;
-
-private:
-    QList<Window*> m_windows;
+    QJsonObject layout;
 };
 
 class WindowModel : public QAbstractListModel

--- a/src/windowmodel.h
+++ b/src/windowmodel.h
@@ -44,7 +44,6 @@ class WindowModel : public QAbstractListModel
     QML_ELEMENT
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
     Q_PROPERTY(Window* focusedWindow READ focusedWindow NOTIFY focusedWindowChanged)
-    Q_PROPERTY(QVariant layout READ windowLayout NOTIFY layoutChanged)
 
 public:
     enum WindowRoles {
@@ -64,12 +63,10 @@ public:
     ~WindowModel();
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-    QVariant windowLayout(const QModelIndex &index) const;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     QHash<int, QByteArray> roleNames() const override;
 
     Window* focusedWindow() const { return m_focusedWindow; }
-    QJsonObject windowLayout() const { return m_windowLayout; }
 
 public slots:
     void handleEvent(const QJsonObject &event);
@@ -77,7 +74,7 @@ public slots:
 signals:
     void countChanged();
     void focusedWindowChanged();
-    void layoutChanged();
+    void windowLayoutChanged();
 
 private:
     void sortWindowsByScrollingPosition();
@@ -94,5 +91,4 @@ private:
 
     QList<Window*> m_windows;
     Window *m_focusedWindow = nullptr;
-    QJsonObject m_windowLayout;
 };

--- a/src/windowmodel.h
+++ b/src/windowmodel.h
@@ -44,7 +44,7 @@ class WindowModel : public QAbstractListModel
     QML_ELEMENT
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
     Q_PROPERTY(Window* focusedWindow READ focusedWindow NOTIFY focusedWindowChanged)
-    Q_PROPERTY(QJsonObject windowLayouts READ windowLayouts NOTIFY windowLayoutsChanged)
+    Q_PROPERTY(QVariant layout READ windowLayout NOTIFY layoutChanged)
 
 public:
     enum WindowRoles {
@@ -64,11 +64,12 @@ public:
     ~WindowModel();
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant windowLayout(const QModelIndex &index) const;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     QHash<int, QByteArray> roleNames() const override;
 
     Window* focusedWindow() const { return m_focusedWindow; }
-    QJsonObject windowLayouts() const { return m_windowLayouts; }
+    QJsonObject windowLayout() const { return m_windowLayout; }
 
 public slots:
     void handleEvent(const QJsonObject &event);
@@ -76,9 +77,10 @@ public slots:
 signals:
     void countChanged();
     void focusedWindowChanged();
-    void windowLayoutsChanged();
+    void layoutChanged();
 
 private:
+    void sortWindowsByScrollingPosition();
     void handleWindowsChanged(const QJsonArray &windows);
     void handleWindowOpenedOrChanged(const QJsonObject &window);
     void handleWindowClosed(quint64 id);
@@ -92,5 +94,5 @@ private:
 
     QList<Window*> m_windows;
     Window *m_focusedWindow = nullptr;
-    QJsonObject m_windowLayouts;
+    QJsonObject m_windowLayout;
 };

--- a/test/test_windows.qml
+++ b/test/test_windows.qml
@@ -34,6 +34,10 @@ ApplicationWindow {
         onFocusedWindowChanged: {
             console.log("Focused window changed:", niri.focusedWindow?.title)
         }
+
+        onWindowLayoutChanged: {
+          console.log("Window layout changed:", JSON.stringify(niri.focusedWindow?.layout))
+        }
     }
 
     ColumnLayout {


### PR DESCRIPTION
Thanks for your work on this plugin!

I have used it to write a simple shell with a workspace and window pill style indicator that help hint at the topology.
I came up against an issue however, without access to window layout properties there's no real way for me to sort within QML that mimic the spacial layout.
I care much more about the spacial arrangement of my windows than I do about their ID's for my use case.

Be warned, I am no C++ or Qt wizard, I was just desperate to get the intended behavior.
Please give me the feedback I need to fix any misunderstandings I've implemented, suggest things I've missed, go ahead and adjust things to the way you prefer them, or ignore entirely if I've gone in a direction that doesn't match your vision.
This is useful to me, so hopefully it's useful to others :)

<img width="1599" height="1200" alt="image" src="https://github.com/user-attachments/assets/a31a75c2-9e6c-4e46-963e-24d5f8f78bc8" />