### PR TITLE
Expose "ToggleOverview" message for exposing Niri's workspace overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Pull requests to improve the testing situation, add unit tests, etc., are very w
 - `focusWindow(id)` - Focus specific window
 - `closeWindow(id)` - Close specific window
 - `closeWindowOrFocused()` - Close focused window
+- `toggleOverview()` - Shows or hides the workspace overview
 
 *Signals:*
 - `connected()` - Emitted on successful connection

--- a/src/niri.cpp
+++ b/src/niri.cpp
@@ -112,6 +112,14 @@ void Niri::closeWindowOrFocused(quint64 id)
     sendAction(action);
 }
 
+void Niri::toggleOverview()
+{
+    QJsonObject action;
+    action["ToggleOverview"] = QJsonObject{};
+
+    sendAction(action);
+}
+
 void Niri::sendAction(const QJsonObject &action)
 {
     if (!isConnected()) {

--- a/src/niri.h
+++ b/src/niri.h
@@ -33,6 +33,8 @@ public:
     Q_INVOKABLE void closeWindow(quint64 id);
     Q_INVOKABLE void closeWindowOrFocused(quint64 id = 0);
 
+    Q_INVOKABLE void toggleOverview();
+
 signals:
     void connected();
     void disconnected();


### PR DESCRIPTION
Hi there,

I was testing out this for my personal distribution / environment needs and noticed that it wasn't possible to show the overview using a widget. 

It was simple enough to expose this to get it working on my end, so I figured I'd upstream it. I understand that quickshell will eventually be adding native Niri support themselves, but if others might need this in the meantime I figure it would be best to share. :)

One question about the general IPC binding: If I wanted to send a single  "OverviewState" query and fetch the state back from it (for example, `{"is_open":false}`), is there currently a way to do that "inline" so to speak with a timeout? It would be nice for disabling or enabling a button or changing an icon, for example.

Thanks! 