### PR TITLE
feat: expose window layout properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,16 @@ Available window properties:
 - `isFocused`: Currently focused window
 - `isFloating`: Floating window state
 - `isUrgent`: Window urgency flag
+- `columnIndex`: Tiled window column index in niri's scrolling layout (1-based, 0 if unavailable)
+- `tileIndex`: Tiled window index within its column (1-based, 0 if unavailable)
+- `tileWidth`: Tile width in logical pixels (includes niri decorations like borders)
+- `tileHeight`: Tile height in logical pixels (includes niri decorations like borders)
+- `windowWidth`: Window visual geometry width in logical pixels (without niri decorations)
+- `windowHeight`: Window visual geometry height in logical pixels (without niri decorations)
+- `tilePosX`: Tile X position in current workspace view (`NaN` if unavailable)
+- `tilePosY`: Tile Y position in current workspace view (`NaN` if unavailable)
+- `windowOffsetX`: Window visual geometry X offset inside its tile
+- `windowOffsetY`: Window visual geometry Y offset inside its tile
 - `iconPath`: Absolute path to application icon (empty if not found)
 
 #### Application icons

--- a/src/windowmodel.cpp
+++ b/src/windowmodel.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <limits>
 #include <QDebug>
 #include <QJsonArray>
 #include "icon.h"
@@ -46,6 +47,26 @@ QVariant WindowModel::data(const QModelIndex &index, int role) const
         return win->isFloating;
     case IsUrgentRole:
         return win->isUrgent;
+    case ColumnIndexRole:
+        return win->columnIndex;
+    case TileIndexRole:
+        return win->tileIndex;
+    case TileWidthRole:
+        return win->tileWidth;
+    case TileHeightRole:
+        return win->tileHeight;
+    case WindowWidthRole:
+        return win->windowWidth;
+    case WindowHeightRole:
+        return win->windowHeight;
+    case TilePosXRole:
+        return win->tilePosX;
+    case TilePosYRole:
+        return win->tilePosY;
+    case WindowOffsetXRole:
+        return win->windowOffsetX;
+    case WindowOffsetYRole:
+        return win->windowOffsetY;
     case IconPathRole:
         return win->iconPath;
     default:
@@ -64,6 +85,16 @@ QHash<int, QByteArray> WindowModel::roleNames() const
     roles[IsFocusedRole] = "isFocused";
     roles[IsFloatingRole] = "isFloating";
     roles[IsUrgentRole] = "isUrgent";
+    roles[ColumnIndexRole] = "columnIndex";
+    roles[TileIndexRole] = "tileIndex";
+    roles[TileWidthRole] = "tileWidth";
+    roles[TileHeightRole] = "tileHeight";
+    roles[WindowWidthRole] = "windowWidth";
+    roles[WindowHeightRole] = "windowHeight";
+    roles[TilePosXRole] = "tilePosX";
+    roles[TilePosYRole] = "tilePosY";
+    roles[WindowOffsetXRole] = "windowOffsetX";
+    roles[WindowOffsetYRole] = "windowOffsetY";
     roles[IconPathRole] = "iconPath";
     return roles;
 }
@@ -217,9 +248,34 @@ void WindowModel::handleWindowUrgencyChanged(quint64 id, bool urgent)
 
 void WindowModel::handleWindowLayoutsChanged(const QJsonArray &changes)
 {
-    // Window layout changes don't affect the properties we're tracking
-    // This is mostly for position/size which we're not exposing yet
-    Q_UNUSED(changes);
+    static const QList<int> layoutRoles = {
+        ColumnIndexRole,
+        TileIndexRole,
+        TileWidthRole,
+        TileHeightRole,
+        WindowWidthRole,
+        WindowHeightRole,
+        TilePosXRole,
+        TilePosYRole,
+        WindowOffsetXRole,
+        WindowOffsetYRole
+    };
+
+    for (const QJsonValue &changeValue : changes) {
+        const QJsonArray change = changeValue.toArray();
+        const quint64 id = change.at(0).toInteger();
+        const QJsonObject layoutObj = change.at(1).toObject();
+
+        const int idx = findWindowIndex(id);
+        if (idx == -1) {
+            qCWarning(niriLog) << "Window not found for layout change:" << id;
+            continue;
+        }
+
+        parseWindowLayout(m_windows[idx], layoutObj);
+        const QModelIndex modelIdx = index(idx);
+        emit dataChanged(modelIdx, modelIdx, layoutRoles);
+    }
 }
 
 Window* WindowModel::parseWindow(const QJsonObject &obj)
@@ -238,9 +294,34 @@ Window* WindowModel::parseWindow(const QJsonObject &obj)
     win->isFocused = obj["is_focused"].toBool();
     win->isFloating = obj["is_floating"].toBool();
     win->isUrgent = obj["is_urgent"].toBool();
+    parseWindowLayout(win, obj["layout"].toObject());
     win->iconPath = IconLookup::lookup(win->appId);
 
     return win;
+}
+
+void WindowModel::parseWindowLayout(Window *window, const QJsonObject &layoutObj)
+{
+    const QJsonArray scrollingPos = layoutObj.value("pos_in_scrolling_layout").toArray();
+    window->columnIndex = scrollingPos.at(0).toInt();
+    window->tileIndex = scrollingPos.at(1).toInt();
+
+    const QJsonArray tileSize = layoutObj.value("tile_size").toArray();
+    window->tileWidth = tileSize.at(0).toDouble();
+    window->tileHeight = tileSize.at(1).toDouble();
+
+    const QJsonArray windowSize = layoutObj.value("window_size").toArray();
+    window->windowWidth = windowSize.at(0).toInt();
+    window->windowHeight = windowSize.at(1).toInt();
+
+    const qreal noTilePos = std::numeric_limits<qreal>::quiet_NaN();
+    const QJsonArray tilePos = layoutObj.value("tile_pos_in_workspace_view").toArray();
+    window->tilePosX = tilePos.at(0).toDouble(noTilePos);
+    window->tilePosY = tilePos.at(1).toDouble(noTilePos);
+
+    const QJsonArray windowOffset = layoutObj.value("window_offset_in_tile").toArray();
+    window->windowOffsetX = windowOffset.at(0).toDouble();
+    window->windowOffsetY = windowOffset.at(1).toDouble();
 }
 
 int WindowModel::findWindowIndex(quint64 id) const

--- a/src/windowmodel.h
+++ b/src/windowmodel.h
@@ -4,6 +4,7 @@
 #include <QJsonObject>
 #include <QObject>
 #include <QQmlEngine>
+#include <limits>
 
 class Window : public QObject
 {
@@ -17,12 +18,28 @@ class Window : public QObject
     Q_PROPERTY(bool isFocused MEMBER isFocused CONSTANT)
     Q_PROPERTY(bool isFloating MEMBER isFloating CONSTANT)
     Q_PROPERTY(bool isUrgent MEMBER isUrgent CONSTANT)
+    Q_PROPERTY(qint32 columnIndex MEMBER columnIndex CONSTANT)
+    Q_PROPERTY(qint32 tileIndex MEMBER tileIndex CONSTANT)
+    Q_PROPERTY(qreal tileWidth MEMBER tileWidth CONSTANT)
+    Q_PROPERTY(qreal tileHeight MEMBER tileHeight CONSTANT)
+    Q_PROPERTY(qint32 windowWidth MEMBER windowWidth CONSTANT)
+    Q_PROPERTY(qint32 windowHeight MEMBER windowHeight CONSTANT)
+    Q_PROPERTY(qreal tilePosX MEMBER tilePosX CONSTANT)
+    Q_PROPERTY(qreal tilePosY MEMBER tilePosY CONSTANT)
+    Q_PROPERTY(qreal windowOffsetX MEMBER windowOffsetX CONSTANT)
+    Q_PROPERTY(qreal windowOffsetY MEMBER windowOffsetY CONSTANT)
     Q_PROPERTY(QString iconPath MEMBER iconPath CONSTANT)
 
 public:
     explicit Window(QObject *parent = nullptr)
         : QObject(parent), id(0), pid(-1), workspaceId(0),
-          isFocused(false), isFloating(false), isUrgent(false) {}
+          isFocused(false), isFloating(false), isUrgent(false),
+          columnIndex(0), tileIndex(0),
+          tileWidth(0), tileHeight(0),
+          windowWidth(0), windowHeight(0),
+          tilePosX(std::numeric_limits<qreal>::quiet_NaN()),
+          tilePosY(std::numeric_limits<qreal>::quiet_NaN()),
+          windowOffsetX(0), windowOffsetY(0) {}
 
     quint64 id;
     QString title;
@@ -32,6 +49,16 @@ public:
     bool isFocused;
     bool isFloating;
     bool isUrgent;
+    qint32 columnIndex;
+    qint32 tileIndex;
+    qreal tileWidth;
+    qreal tileHeight;
+    qint32 windowWidth;
+    qint32 windowHeight;
+    qreal tilePosX;
+    qreal tilePosY;
+    qreal windowOffsetX;
+    qreal windowOffsetY;
     QString iconPath;
 };
 
@@ -52,7 +79,17 @@ public:
         IsFocusedRole,
         IsFloatingRole,
         IsUrgentRole,
-        IconPathRole
+        IconPathRole,
+        ColumnIndexRole,
+        TileIndexRole,
+        TileWidthRole,
+        TileHeightRole,
+        WindowWidthRole,
+        WindowHeightRole,
+        TilePosXRole,
+        TilePosYRole,
+        WindowOffsetXRole,
+        WindowOffsetYRole
     };
 
     explicit WindowModel(QObject *parent = nullptr);
@@ -78,6 +115,7 @@ private:
     void handleWindowFocusChanged(const QJsonValue &idValue);
     void handleWindowUrgencyChanged(quint64 id, bool urgent);
     void handleWindowLayoutsChanged(const QJsonArray &changes);
+    void parseWindowLayout(Window *window, const QJsonObject &layoutObj);
 
     Window* parseWindow(const QJsonObject &obj);
     int findWindowIndex(quint64 id) const;


### PR DESCRIPTION
Exposes window layout fields from niri IPC on `Window` / `WindowModel`, so QML can sort and render windows by layout position without custom event parsing.

Related context: #5 and [this comment](https://github.com/imiric/qml-niri/issues/5#issuecomment-3693892993).

### Changes

 - Added new window roles/properties:
   - `columnIndex`, `tileIndex`
   - `tileWidth`, `tileHeight`
   - `windowWidth`, `windowHeight`
   - `tilePosX`, `tilePosY`
   - `windowOffsetX`, `windowOffsetY`
 - Populate these fields from `window.layout` in `parseWindow()`.
 - Handle `WindowLayoutsChanged` and emit `dataChanged(...)` for layout roles.
 - Updated the README window property list.

### Notes

 - `columnIndex` / `tileIndex` map to `pos_in_scrolling_layout` (1-based in niri, 0 when unavailable).
 - `tilePosX` / `tilePosY` use `NaN` when `tile_pos_in_workspace_view` is unavailable.
 - This PR does not introduce a built-in sorting policy. Sorting remains a QML-side decision (`SortFilterProxyModel`, `RoleSorter`, etc.).
 - niri IPC represents layout as a nested structure ([Window](https://niri-wm.github.io/niri/niri_ipc/struct.Window.html), [WindowLayout](https://niri-wm.github.io/niri/niri_ipc/struct.WindowLayout.html)). This change exposes layout data as flat roles (`columnIndex`, `tileIndex`, etc.) so they can be used directly with `SortFilterProxyModel` / `RoleSorter` in QML. If you have a better design in mind, I’m happy to discuss and adjust.

### Example (QML)
```qml
pragma Singleton

import Niri
import QtQml

Niri {
    id: niri
    readonly property SortFilterProxyModel sortedWindows: SortFilterProxyModel {
        model: niri.windows
        sorters: [
            RoleSorter {
                roleName: "columnIndex"
            },
            RoleSorter {
                roleName: "tileIndex"
            }
        ]
    }

    Component.onCompleted: connect()
    onConnected: console.log("Connected to niri")
    onErrorOccurred: error => console.error("Niri error:", error)
}
```