### PR TITLE
build: add CMake install rules with relocatable RUNPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ find_package(Qt6 REQUIRED COMPONENTS Core Gui Qml)
 
 qt_standard_project_setup(REQUIRES 6.5)
 
+set(CMAKE_INSTALL_RPATH "$ORIGIN")
+set(QML_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/qt6/qml"
+    CACHE PATH "QML module install directory")
+
 qt_add_library(Niri SHARED)
 
 set_target_properties(Niri PROPERTIES
@@ -37,3 +41,13 @@ target_link_libraries(Niri PRIVATE
 )
 
 target_compile_definitions(Niri PRIVATE QT_USE_QSTRINGBUILDER)
+
+install(TARGETS Niri Niriplugin
+    LIBRARY DESTINATION "${QML_INSTALL_DIR}/Niri"
+)
+
+install(FILES
+    "${CMAKE_BINARY_DIR}/Niri/qmldir"
+    "${CMAKE_BINARY_DIR}/Niri/Niri.qmltypes"
+    DESTINATION "${QML_INSTALL_DIR}/Niri"
+)

--- a/README.md
+++ b/README.md
@@ -69,17 +69,39 @@ The `just build` command will create a `build` directory and compile the plugin.
 
 ### Installing system-wide
 
-After building, copy the plugin to your QML import path:
-
+After building, install the plugin with:
 ```bash
-# Find your QML import path
-qtpaths6 --qt-query QT_INSTALL_QML
-
-# Copy the plugin (adjust path as needed)
-sudo cp -r build/Niri /usr/lib64/qt6/qml/
+sudo just install
 ```
 
-Alternatively, you can set the `QML_IMPORT_PATH` environment variable to include the build directory when running your QML applications.
+This installs into your Qt QML import path under the `/usr` prefix (e.g. `/usr/lib64/qt6/qml/Niri`), which should work for most distributions.
+
+If your distribution uses a different prefix, pass it explicitly:
+```bash
+sudo just install /usr/local
+```
+
+You can check your QML import path with:
+```bash
+# Note: use the Qt6 qtpaths, which may not be on your PATH by default
+/usr/lib/qt6/bin/qtpaths --qt-query QT_INSTALL_QML
+```
+
+Alternatively, during development or to avoid a system-wide install, set the `QML_IMPORT_PATH` environment variable to include the build directory when running your QML application:
+```bash
+QML_IMPORT_PATH="$PWD/build" <your-qml-command>
+```
+
+### Packaging
+
+For packaging, configure the prefix and stage into `DESTDIR`:
+```bash
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
+cmake --build build
+DESTDIR="$pkgdir" cmake --install build
+```
+
+The QML install directory can be overridden with `-DQML_INSTALL_DIR=...`.
 
 
 ## Usage
@@ -590,9 +612,13 @@ and have no corresponding signal.
 ## Troubleshooting
 
 - `module "Niri" is not installed`:
-  Ensure `QML_IMPORT_PATH` includes the directory containing the `Niri` directory (not the `Niri` directory itself), or that you copied to plugin to an existing QML import path (e.g. `/usr/lib64/qt6/qml/`).
+  This means the QML engine can't find the plugin. Check the following:
 
-  Also, confirm that you're using Qt 6, and not older versions. You can do this with `qml --version`. If the Qt 6 binary is not on your `$PATH` (e.g. on Void Linux it is at `/usr/lib/qt6/bin/qml`), you can symlink it as `qml6` somewhere on your `$PATH`.
+  - If you installed system-wide, confirm the files landed in your Qt QML import path (e.g. `/usr/lib64/qt6/qml/Niri/`). If `just install` used the wrong prefix, reinstall with the correct one (see [Installation](#installation)).
+
+  - If you're running from the build directory instead, ensure `QML_IMPORT_PATH` points to the directory *containing* the `Niri` directory (i.e. `build`), not the `Niri` directory itself.
+
+  - Confirm you're using Qt 6, not an older version, with `qml --version`. If the Qt 6 binary isn't on your `$PATH` (e.g. on Void Linux it's at `/usr/lib/qt6/bin/qml`), symlink it as `qml6` somewhere on your `$PATH`.
 
 - *Connection failed*:
   Ensure niri is actually running. 😄

--- a/justfile
+++ b/justfile
@@ -1,12 +1,14 @@
 all: build
 
 build:
-  mkdir -p build
-  cd build && cmake ..
-  cd build && make
+  cmake -B build -DCMAKE_BUILD_TYPE=Release
+  cmake --build build
+
+install prefix="/usr":
+  cmake --install build --prefix {{prefix}}
 
 clean:
   rm -rf build
 
 test component:
-  QML_IMPORT_PATH=$PWD/build qml6 test/test_{{component}}.qml
+  QML_IMPORT_PATH="$PWD/build" qml6 test/test_{{component}}.qml


### PR DESCRIPTION
Previously the plugin was distributed by manually copying the build output into the QML import path, which left the build-directory `RUNPATH` embedded in libNiriplugin.so, and complicated distro packaging.

This adds `install()` rules and sets `INSTALL_RPATH` to `$ORIGIN` so the installed libraries locate each other relative to their own directory. The QML install location is now controlled by the overridable `QML_INSTALL_DIR` cache variable, defaulting to the Qt QML path under the install prefix.

Also updates the justfile with an install recipe and revises the README installation, packaging, and troubleshooting sections accordingly.

Closes #20